### PR TITLE
Use MODE=0660 for 187c devices

### DIFF
--- a/app/70-awcc.rules
+++ b/app/70-awcc.rules
@@ -1,2 +1,2 @@
-SUBSYSTEM=="usb", ATTRS{idVendor}=="187c", ATTRS{idProduct}=="0551", MODE="0666", TAG+="uaccess"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="187c", ATTRS{idProduct}=="0550", MODE="0666", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="187c", ATTRS{idProduct}=="0551", MODE="0660", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="187c", ATTRS{idProduct}=="0550", MODE="0660", TAG+="uaccess"


### PR DESCRIPTION
Use MODE=0660 instead of 0666 in the 70-awcc.rules file