### PR TITLE
add support for Alienware m15 r6 

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Need support or want this project to support your device ? Join our [Discord com
 - Alienware Aurora Ryzen Edition
 - Alienware m15 R3
 - Alienware m15 R4
+- Alienware m15 R6
 - Alienware m15 R7
 - Alienware m15 Ryzen Ed. R5
 - Alienware m16 R1

--- a/database.json
+++ b/database.json
@@ -95,6 +95,20 @@
         "thermalModes": "11000000",
         "lightingModes": "111111"
     },
+    "Alienware m15 R6": {
+        "featureSet": "1111111",
+        "thermalModes": "11110111",
+        "lightingModes": "111111",
+        "keyboardZones":  [
+            "0x1",
+            "0x3",
+            "0x4",
+            "0x5",
+            "0x6",
+            "0x7",
+            "0x200"
+        ]
+    },
     "Alienware m15 R7": {
         "featureSet": "1111111",
         "thermalModes": "11101111",


### PR DESCRIPTION
## Lighting Zones Implementation

This implementation maps each lighting region to a hexadecimal ID, allowing the software to control each zone independently.  
In practice, these IDs act as an addressing table: when a command is sent to an ID, only the corresponding zone is updated.

## Zone Description

- Left Rear Panel (Upper): 0x1
- Keyboard Alien Head Logo: 0x2
- Display Alien Head Logo: 0x3
- Keyboard Zone 1 (Left): 0x4
- Keyboard Zone 2 (Center-Left): 0x5
- Keyboard Zone 3 (Center-Right): 0x6
- Keyboard Zone 4 (Right): 0x7
- Left Rear Panel (Lower): 0x200
I have particularly removed 0x2 from RGB control because i guess theres a bios config to set it to green when the power cable is connected, and this was interfering in the awcc rgb display