### PR TITLE
Allow daemon startup without internal keyboard

### DIFF
--- a/include/KeyBinder.h
+++ b/include/KeyBinder.h
@@ -14,6 +14,7 @@ class KeyBinder {
 
     void setOnGModeKey(std::function<void()> cb);
     void setOnLightKey(std::function<void()> cb);
+    [[nodiscard]] bool isAvailable() const { return dev_ != nullptr; }
     void run();
     void stop();
 

--- a/src/Daemon.cpp
+++ b/src/Daemon.cpp
@@ -120,12 +120,19 @@ void Daemon::init() {
         exit(1);
     }
 
-    // NOTE: Start the key binder module
+    // Desktop systems do not expose the internal laptop keyboard used for
+    // Alienware hotkeys. Keep the daemon usable and only skip those hotkeys.
     m_binder = new KeyBinder("AT Translated Set 2 keyboard");
-    m_binder->setOnGModeKey([this]() { this->m_onGmodeKey(); });
-    m_binder->setOnLightKey([this]() { this->m_onLightKey(); });
-
-    m_keybinderThread = std::thread([this]() { this->m_binder->run(); });
+    if (m_binder->isAvailable()) {
+        m_binder->setOnGModeKey([this]() { this->m_onGmodeKey(); });
+        m_binder->setOnLightKey([this]() { this->m_onLightKey(); });
+        m_keybinderThread = std::thread([this]() { this->m_binder->run(); });
+    } else {
+        LOG_S(WARNING) << "Internal keyboard hotkeys unavailable; continuing "
+                          "without KeyBinder";
+        delete m_binder;
+        m_binder = nullptr;
+    }
 
     signal(SIGINT, daemon_signal_handler);
     signal(SIGTERM, daemon_signal_handler);
@@ -161,12 +168,6 @@ void Daemon::init() {
     LOG_S(INFO) << "Daemon listening on " << m_socket_path;
 
     while (m_running) {
-        if (!m_keybinderThread.joinable()) {
-            LOG_S(ERROR) << "KeyBinder thread has exited!";
-            m_StopBinder();
-            break;
-        }
-
         int client_fd = accept(m_server_fd, nullptr, nullptr);
         if (client_fd < 0) {
             if (errno == EINTR)

--- a/src/Daemon.cpp
+++ b/src/Daemon.cpp
@@ -168,6 +168,13 @@ void Daemon::init() {
     LOG_S(INFO) << "Daemon listening on " << m_socket_path;
 
     while (m_running) {
+        if (m_binder != nullptr && m_binder->isAvailable() &&
+            !m_keybinderThread.joinable()) {
+            LOG_S(ERROR) << "KeyBinder thread has exited!";
+            m_StopBinder();
+            break;
+        }
+
         int client_fd = accept(m_server_fd, nullptr, nullptr);
         if (client_fd < 0) {
             if (errno == EINTR)

--- a/src/KeyBinder.cpp
+++ b/src/KeyBinder.cpp
@@ -31,7 +31,7 @@ KeyBinder::KeyBinder(const std::string &target_device_name, double timeout_sec)
         }
     }
     if (dev_ == nullptr) {
-        LOG_S(ERROR) << "Device " << target_device_name << " not found!";
+        LOG_S(WARNING) << "Device " << target_device_name << " not found!";
     } else {
         LOG_S(INFO) << "KeyBinder module initialized";
     }


### PR DESCRIPTION
## Summary

This PR allows the daemon to continue startup when the expected internal keyboard device is not available.

On the Alienware Area-51 AAT2250 desktop, there is no `AT Translated Set 2 keyboard`. Previously, daemon startup failed during KeyBinder initialization.

With this change:
- missing KeyBinder target is treated as a warning
- daemon startup continues
- G-Mode / lighting hotkeys are skipped when KeyBinder is unavailable
- thermal/fan control paths are unchanged

## Tested

Tested on:
- Alienware Area-51 AAT2250 desktop
- Arch Linux

Not tested on laptop hardware. The change is intended to preserve the existing laptop path: if the internal keyboard is available, KeyBinder should continue to be initialized as before. If it is not available, the daemon now continues without hotkey support.

Verification:
- `cmake -S . -B build -G Ninja`
- `cmake --build build`
- `git diff --check`

Changed files:
- `include/KeyBinder.h`
- `src/KeyBinder.cpp`
- `src/Daemon.cpp`