### PR TITLE
feat(nixos): add flake input for NixOS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ AGENTS.md
 build/
 .cache/
 imgui.ini
+result

--- a/README.md
+++ b/README.md
@@ -65,6 +65,33 @@ paru -S awcc-bin
 - `ninja`
 - `meson`
 
+
+#### 🗿 For NixOS
+
+Add flake input in your config:
+
+```nix
+awcc = {
+  url = "github:tr1xem/AWCC";
+  inputs.nixpkgs.follows = "nixpkgs";
+}
+```
+
+Then, import `awcc.nixosModules.default` anywhere in your config and add `acpi_call` as kernel module.
+
+Example flake part `awcc.nix` setup:
+
+```nix
+{ ... }: {
+  flake.modules.nixos."system.awcc" = { inputs, config, pkgs, ... }: {
+    imports = [ inputs.awcc.nixosModules.default ];
+    boot.kernelModules = [ "acpi_call" ];
+    boot.extraModulePackages = with config.boot.kernelPackages; [ acpi_call ];
+  };
+}
+```
+
+
 OR if you are a debianoid
 
 ```
@@ -118,8 +145,6 @@ script_timeout=3
 ```
 
 and now edit game's launch command to use gamemode `gamemoderun ./game` (or `gamemoderun %command%` if you are using steam) and it would autotoggle gmode on starting a game
-
-Thanks to [@kevin](https://github.com/kraaijmakers) for this snippet
 
 ## Support and Feedback
 
@@ -201,7 +226,9 @@ Need support or want this project to support your device ? Join our [Discord com
 
 - [GasparVardanyan](https://github.com/GasparVardanyan)
 - [humanfx](https://github.com/tiagoporsch/humanfx)
+- [randomboi404](https://github.com/randomboi404) (NixOS Support)
 - [meduk0](https://github.com/meduk0)
+- [kevin](https://github.com/kraaijmakers) (G-Mode snippet)
 - [WMI Kernel Driver](https://docs.kernel.org/6.16/wmi/devices/alienware-wmi.html)
 
 **“Intelligence is the ability to avoid doing work, yet getting the work done.”** _~Linus Torvalds_

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,40 @@
+{
+  description = "AWCC - Unofficial Alienware Command Centre for Linux";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      forAllSystems = nixpkgs.lib.genAttrs [ "x86_64-linux" "aarch64-linux" ];
+    in {
+      packages = forAllSystems (system: let
+        pkgs = import nixpkgs { inherit system; };
+      in {
+        awcc = pkgs.callPackage ./nix/package.nix {
+          waylandScanner = pkgs."wayland-scanner";
+        };
+        default = self.packages.${system}.awcc;
+      });
+
+      devShells = forAllSystems (system: let
+        pkgs = import nixpkgs { inherit system; };
+      in {
+        default = pkgs.mkShell {
+          name = "awcc-dev";
+          packages = with pkgs; [
+            cmake ninja meson pkg-config wayland wayland-scanner wayland-protocols
+            libusb1 libevdev udev
+            libglvnd libx11 libxrandr libxinerama libxcursor libxi
+            libxkbcommon
+          ];
+        };
+      });
+
+      nixosModules = {
+        awcc = import ./nix/module.nix;
+        default = self.nixosModules.awcc;
+      };
+    };
+}

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,0 +1,75 @@
+{ lib, pkgs, config, ... }:
+
+let
+  cfg = config.services.awcc;
+  defaultPackage = (pkgs.callPackage ./package.nix { waylandScanner = pkgs."wayland-scanner"; }).overrideAttrs (old: {
+    preConfigure = (old.preConfigure or "") + ''
+
+      # NixOS patches
+
+      # Font footer null dereference (--gui SIGSEGV)
+      sed -i '/^         ImFont \&fontbold, int \&brightness, EffectController \&effects,$/a\         ImFont \&fontfooter,' include/Gui.h
+      sed -i 's/EffectController \&effects, bool \&turbo)/EffectController \&effects, ImFont \&fontfooter, bool \&turbo)/' src/gui/Gui.cpp
+      sed -i '/^        static ImGuiIO \&io = ImGui::GetIO();$/,/^        ImGui::PushFont(fontfooter);$/c\        ImGui::PushFont(\&fontfooter);' src/gui/Gui.cpp
+      sed -i '/roboto_light, static_cast<int>(roboto_light_len), 17\.0F, \&cfg);/a\
+        ImFont *fontfooter = io.Fonts->AddFontFromMemoryTTF(\
+            roboto_medium, roboto_medium_len, 15.0F, \&cfg);' src/gui/Render.cpp
+      sed -i 's/\*smallFont, \*fontbold, brightness, effects, turbo)/*smallFont, *fontbold, brightness, effects, *fontfooter, turbo)/' src/gui/Render.cpp
+
+      # Strip pkexec/sudo from daemon-bound commands (daemon runs as root)
+      sed -i 's|result = m_daemon\.executeFromDaemon(command\.c_str());|{ std::string dCmd = command; size_t pp = dCmd.find("pkexec "); if (pp != std::string::npos) dCmd.erase(pp, 7); result = m_daemon.executeFromDaemon(dCmd.c_str()); }|' src/AcpiUtils.cpp
+      sed -i 's|m_daemon\.executeFromDaemon(cmd\.c_str());|{ auto p = cmd.find("sudo "); if (p != std::string::npos) cmd.erase(p, 5); m_daemon.executeFromDaemon(cmd.c_str()); }|' src/AcpiUtils.cpp
+      sed -i 's|pkexec sh|(?:pkexec )?sh|' src/Daemon.cpp
+      sed -i 's~\\| sudo tee~\\| (?:sudo )?tee~g' src/Daemon.cpp
+
+      # Allow root (sudo) clients to connect to daemon
+      sed -i 's|cred.uid != EXPECTED_UID|cred.uid != EXPECTED_UID \&\& cred.uid != 0|' src/Daemon.cpp
+    '';
+  });
+in {
+  options.services.awcc = {
+    enable = lib.mkEnableOption "AWCC daemon and udev rules";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = defaultPackage;
+      defaultText = lib.literalExpression "(pkgs.callPackage ./package.nix { }).overrideAttrs ...";
+      description = "AWCC package to use (patched for NixOS compat)";
+    };
+
+    daemon = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Enable the AWCC systemd daemon";
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    services.udev.packages = [ cfg.package ];
+
+    environment.etc."awcc/database.json".source = "${cfg.package}/share/awcc/database.json";
+
+    systemd.services.awccd = lib.mkIf cfg.daemon.enable {
+      description = "Alienware Command Centre Daemon";
+      documentation = [ "https://github.com/tr1xem/AWCC" ];
+      after = [ "multi-user.target" ];
+      wants = [ "multi-user.target" ];
+      wantedBy = [ "multi-user.target" ];
+      path = with pkgs; [ bash coreutils-full ];
+      serviceConfig = {
+        Type = "simple";
+        ExecStartPre = "-${pkgs.coreutils}/bin/rm -f /tmp/awcc.sock";
+        ExecStart = "${cfg.package}/bin/awcc -d -v";
+        ExecStop = "${pkgs.coreutils}/bin/kill -TERM $MAINPID";
+        Restart = "always";
+        RestartSec = "5";
+        User = "root";
+        Group = "root";
+      };
+    };
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,179 @@
+{ lib, stdenv, cmake, ninja, pkg-config
+, libusb1, libevdev, udev
+, libglvnd, libx11, libxrandr, libxinerama, libxcursor, libxi
+, libxkbcommon, wayland, wayland-protocols
+, waylandScanner
+, loguru, nlohmann_json, glfw, stb
+, fetchFromGitHub
+}:
+
+let
+  imgui-src = fetchFromGitHub {
+    owner = "ocornut";
+    repo = "imgui";
+    rev = "v1.91.8";
+    hash = "sha256-+BuSAXvLvOYOmENzxd1pGDE6llWhTGVu7C3RnoVLVzg=";
+  };
+in stdenv.mkDerivation {
+  pname = "awcc";
+  version = "1.19.0";
+
+  src = lib.cleanSource ./..;
+
+  nativeBuildInputs = [ cmake ninja pkg-config waylandScanner wayland-protocols ];
+
+  buildInputs = [
+    libusb1 libevdev udev
+    libglvnd libx11 libxrandr libxinerama libxcursor libxi
+    libxkbcommon wayland
+    loguru nlohmann_json glfw stb
+  ];
+
+  cmakeFlags = [
+    "-DFETCHCONTENT_SOURCE_DIR_IMGUI=${imgui-src}"
+    "-DUDEV_RULES_DIR=${placeholder "out"}/lib/udev/rules.d"
+    "-DAWCC_CONFIG_DIR=${placeholder "out"}/share/awcc"
+    "-DSYSTEMD_UNIT_DIR=${placeholder "out"}/etc/systemd/system"
+  ];
+
+  NIX_CFLAGS_COMPILE = [ "-I${stb}/include/stb" ];
+
+  preConfigure =
+    let
+      libusbBlock = ''
+# ===================== libusb =====================
+set(LIBUSB_BUILD_SHARED
+    OFF
+    CACHE BOOL "" FORCE)
+set(LIBUSB_BUILD_STATIC
+    ON
+    CACHE BOOL "" FORCE)
+
+FetchContent_Declare(
+  libusb
+  GIT_REPOSITORY https://github.com/libusb/libusb-cmake.git
+  GIT_TAG main
+  GIT_SHALLOW TRUE)
+FetchContent_MakeAvailable(libusb)'';
+      libusbReplace = ''
+# ===================== libusb =====================
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(LIBUSB REQUIRED libusb-1.0 IMPORTED_TARGET)
+add_library(usb-1.0 INTERFACE IMPORTED)
+target_link_libraries(usb-1.0 INTERFACE PkgConfig::LIBUSB)'';
+      libevdevBlock = ''
+# ===================== libevdev ============================================
+include(ExternalProject)
+
+ExternalProject_Add(
+  libevdev
+  GIT_REPOSITORY https://gitlab.freedesktop.org/libevdev/libevdev.git
+  GIT_TAG master
+  CONFIGURE_COMMAND
+    meson setup <BINARY_DIR> <SOURCE_DIR> --default-library=static
+    -Ddocumentation=disabled -Dtests=disabled -Dtools=disabled
+  BUILD_COMMAND meson compile -C <BINARY_DIR>
+  INSTALL_COMMAND "" # CMAKE NEEDS A INSTALL COMMAND or it will run make
+  BUILD_BYPRODUCTS <BINARY_DIR>/libevdev.a)
+
+add_library(libevdev::libevdev STATIC IMPORTED)
+
+ExternalProject_Get_Property(libevdev source_dir binary_dir)
+
+set_target_properties(
+  libevdev::libevdev PROPERTIES IMPORTED_LOCATION ''${binary_dir}/libevdev.a
+                                INTERFACE_INCLUDE_DIRECTORIES ''${source_dir})
+
+add_dependencies(libevdev::libevdev libevdev)'';
+      libevdevReplace = ''
+# ===================== libevdev ============================================
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(LIBEVDEV REQUIRED libevdev>=1.0 IMPORTED_TARGET)
+add_library(libevdev::libevdev INTERFACE IMPORTED)
+target_link_libraries(libevdev::libevdev INTERFACE PkgConfig::LIBEVDEV)'';
+      loguruBlock = ''
+FetchContent_Declare(
+  loguru
+  GIT_REPOSITORY https://github.com/emilk/loguru
+  GIT_TAG master
+  GIT_SHALLOW TRUE)
+set(LOGURU_WITH_STREAMS
+    TRUE
+    CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(loguru)'';
+      jsonBlock = ''
+FetchContent_Declare(
+  json
+  GIT_REPOSITORY https://github.com/nlohmann/json.git
+  GIT_TAG master
+  GIT_SHALLOW TRUE)
+FetchContent_MakeAvailable(json)'';
+      glfwBlock = ''
+set(GLFW_BUILD_EXAMPLES
+    OFF
+    CACHE BOOL "" FORCE)
+set(GLFW_BUILD_TESTS
+    OFF
+    CACHE BOOL "" FORCE)
+set(GLFW_BUILD_DOCS
+    OFF
+    CACHE BOOL "" FORCE)
+set(GLFW_INSTALL
+    OFF
+    CACHE BOOL "" FORCE)
+
+FetchContent_Declare(
+  glfw
+  GIT_REPOSITORY https://github.com/glfw/glfw.git
+  GIT_TAG master
+  GIT_SHALLOW TRUE)
+FetchContent_MakeAvailable(glfw)'';
+      stbBlock = ''
+FetchContent_Declare(
+  stb
+  GIT_REPOSITORY https://github.com/nothings/stb.git
+  GIT_TAG master
+  GIT_SHALLOW TRUE)
+FetchContent_MakeAvailable(stb)'';
+    in ''
+    # Make install destinations relative so they respect CMAKE_INSTALL_PREFIX
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'RUNTIME DESTINATION /usr/bin' 'RUNTIME DESTINATION bin' \
+      --replace-fail 'DESTINATION /usr/share/applications' 'DESTINATION share/applications' \
+      --replace-fail 'DESTINATION /usr/share/icons' 'DESTINATION share/icons'
+
+    # Remove forced /usr install prefix
+    substituteInPlace CMakeLists.txt \
+      --replace-fail $'if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)\n  set(CMAKE_INSTALL_PREFIX\n      "/usr"\n      CACHE PATH "Install path prefix" FORCE)\nendif()' ""
+
+    # Use system libraries instead of FetchContent
+    substituteInPlace CMakeLists.txt \
+      --replace-fail '${loguruBlock}' 'find_package(loguru REQUIRED)'
+    substituteInPlace CMakeLists.txt \
+      --replace-fail '${jsonBlock}' 'find_package(nlohmann_json REQUIRED)'
+    substituteInPlace CMakeLists.txt \
+      --replace-fail '${glfwBlock}' 'find_package(glfw3 REQUIRED)'
+    substituteInPlace CMakeLists.txt \
+      --replace-fail '${stbBlock}' '# stb provided by nixpkgs'
+    substituteInPlace CMakeLists.txt \
+      --replace-fail '${libusbBlock}' '${libusbReplace}'
+    substituteInPlace CMakeLists.txt \
+      --replace-fail '${libevdevBlock}' '${libevdevReplace}'
+
+    # Fix link targets
+    substituteInPlace CMakeLists.txt \
+      --replace-fail $'\n          usb-1.0\n          libevdev::libevdev)' $'\n          PkgConfig::LIBUSB\n          PkgConfig::LIBEVDEV)'
+
+    # Remove stb_SOURCE_DIR from include path
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'include ''${stb_SOURCE_DIR}' 'include'
+  '';
+
+  meta = {
+    description = "Unofficial Alienware Command Centre for Linux";
+    homepage = "https://github.com/randomboi404/AWCC";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
+    maintainers = [ ];
+  };
+}


### PR DESCRIPTION
This PR adds support for NixOS. Users can add `tr1xem/awcc` input in their flake inputs and use it. There are some caveats and maybe improved further in future but for the time being, it works perfectly for the current version of AWCC.