### PR TITLE
fix(device): correct ACPI prefix for Alienware m15 R6

### DIFF
--- a/src/AcpiUtils.cpp
+++ b/src/AcpiUtils.cpp
@@ -32,7 +32,8 @@ const char *AcpiUtils::getPrefix() {
     }
     if (deviceName.contains("Alienware m18 R1 AMD") ||
         deviceName.contains("G5 5505") ||
-        deviceName.contains("Alienware m16 R1 AMD")) {
+        deviceName.contains("Alienware m16 R1 AMD") ||
+        deviceName.contains("Alienware m15 R6")) {
         LOG_S(INFO) << "Special prefix detected using: AMWW";
         return "AMWW";
     }


### PR DESCRIPTION
The generic "Alienware m15" substring match was catching the R6 variant and assigning it the AMW1 prefix, but this model's DSDT/SSDT actually expose the WMAX interface under \_SB.AMWW, not \_SB.AMW1. Every WMAX call was failing with AE_NOT_FOUND as a result, so thermal modes, fan control, and G-Mode never worked on this model.

Verified on real Alienware m15 R6 hardware: the compiled ACPI tables contain AMWW/WMAX (no AMW1 anywhere), and after this fix `awcc qm` correctly reports the live thermal mode, matching the kernel's own platform_profile reading.